### PR TITLE
Add a wss config entry to the manager dev proxy

### DIFF
--- a/static/skywire-manager-src/proxy.config.json
+++ b/static/skywire-manager-src/proxy.config.json
@@ -11,5 +11,14 @@
     "pathRewrite": {
       "^/http-api" : "/api"
     }
+  },
+  "/wss-api": {
+    "target": "wss://127.0.0.1:8000",
+    "secure": false,
+    "ws": true,
+    "headers": {"host":"127.0.0.1:8000", "origin":"wss://127.0.0.1:8000", "referer":"wss://127.0.0.1:8000"},
+    "pathRewrite": {
+      "^/wss-api" : "/api"
+    }
   }
 }


### PR DESCRIPTION
 Changes:	
- This PR adds a new config entry to the dev proxy config file of the manager, which can be used for making connections to the wss endpoints without having problems related to the origin headers. It is needed because the proxy is not behaving the same with https and wss.

How to test this PR:
The new proxy rule is not automatically used by the code, more changes are needed. The rule was added for future use.